### PR TITLE
Update actions to windows 2022

### DIFF
--- a/.github/workflows/pipeline_16.1.yaml
+++ b/.github/workflows/pipeline_16.1.yaml
@@ -1,6 +1,3 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by separate terms of service, privacy policy, and support documentation.
-
 name: Build ESAPI Script - v16.1
 
 on:
@@ -9,18 +6,18 @@ on:
       dateInput:
         description: 'Expiration Date'
         required: true
-        default: '1/1/2026'
+        default: '12/31/2025'
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       GITHUB_WORKSPACE_PACKAGES_PATH: packages\ESAPI.16.1.0\lib\net461\
       PROJECT_FOLDER_NAME: MAAS-TXIHelper
       PROJECT_NAME: MAAS_TXIHelper
       MAJOR_VERSION: 1
       MINOR_VERSION: 0
-      PATCH_VERSION: 0
+      PATCH_VERSION: 1
       BUILD_NUMBER: ${{ github.run_number }}
 
     steps:
@@ -52,7 +49,7 @@ jobs:
         nuget-version: latest
     
     - name: Download nuget packages
-      run: nuget install .\MAAS-TXIHelper\packages.config -OutputDirectory .\${{env.PROJECT_FOLDER_NAME}}\packages
+      run: nuget install Microsoft.NETFramework.ReferenceAssemblies.net461 -OutputDirectory .\${{env.PROJECT_FOLDER_NAME}}\packages
    
     - name: Add VIC GitHub NuGet repository
       run: nuget source add

--- a/.github/workflows/pipeline_17.0.yaml
+++ b/.github/workflows/pipeline_17.0.yaml
@@ -1,6 +1,3 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by separate terms of service, privacy policy, and support documentation.
-
 name: Build ESAPI Script - v17.0
 
 on:
@@ -9,18 +6,18 @@ on:
       dateInput:
         description: 'Expiration Date'
         required: true
-        default: '1/1/2026'
+        default: '12/31/2025'
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       GITHUB_WORKSPACE_PACKAGES_PATH: packages\ESAPI.17.0.0\lib\net48\
       PROJECT_FOLDER_NAME: MAAS-TXIHelper
       PROJECT_NAME: MAAS_TXIHelper
       MAJOR_VERSION: 1
       MINOR_VERSION: 0
-      PATCH_VERSION: 0
+      PATCH_VERSION: 1
       BUILD_NUMBER: ${{ github.run_number }}
 
     steps:
@@ -45,15 +42,19 @@ jobs:
           -MinorVersion ${{ env.MINOR_VERSION }} `
           -PatchVersion ${{ env.PATCH_VERSION }} `
           -BuildNumber ${{ env.BUILD_NUMBER }}
-          
+
+    - name: Update Target Framework Version to 4.8
+      uses: Nambers/ReplaceStringInFile@v1.1
+      with:
+        path: ${{ env.PROJECT_FOLDER_NAME }}/${{ env.PROJECT_NAME }}.csproj
+        oldString: "TargetFrameworkVersion>v[\\d\\.]+<"
+        newString: 'TargetFrameworkVersion>v4.8<'
+
     - name: Setup NuGet.exe for use with actions
       uses: NuGet/setup-nuget@v1
       with:
         nuget-version: latest
-    
-    - name: Download nuget packages
-      run: nuget install .\MAAS-TXIHelper\packages.config -OutputDirectory .\${{env.PROJECT_FOLDER_NAME}}\packages
-   
+
     - name: Add VIC GitHub NuGet repository
       run: nuget source add
         -Name github `
@@ -68,11 +69,11 @@ jobs:
     - name: Update hint paths in the csproj file
       run: |
         .\.github\workflows\Update-EsapiHintPaths.ps1 `
-        -CsprojFilePath .\MAAS-TXIHelper `
-        -CsprojFileName MAAS_TXIHelper.csproj
+        -CsprojFilePath .\${{ env.PROJECT_FOLDER_NAME }} `
+        -CsprojFileName ${{ env.PROJECT_NAME }}.csproj
           
     - name: Build Solution
-      run: msbuild.exe .\${{env.PROJECT_FOLDER_NAME}}\${{env.PROJECT_NAME}}.sln /nologo /nr:false /p:DeleteExistingFiles=True /p:platform="x64" /p:configuration="Release"
+      run: msbuild.exe .\${{env.PROJECT_FOLDER_NAME}}\${{env.PROJECT_NAME}}.sln /nologo /nr:false /p:DeleteExistingFiles=True /p:platform="x64" /p:configuration="Release" /restore
         
     - name: Zip
       run: |

--- a/.github/workflows/pipeline_18.0.yaml
+++ b/.github/workflows/pipeline_18.0.yaml
@@ -1,6 +1,3 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by separate terms of service, privacy policy, and support documentation.
-
 name: Build ESAPI Script - v18.0
 
 on:
@@ -9,18 +6,18 @@ on:
       dateInput:
         description: 'Expiration Date'
         required: true
-        default: '1/1/2026'
+        default: '12/31/2025'
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       GITHUB_WORKSPACE_PACKAGES_PATH: packages\ESAPI.18.0.0\lib\net48\
       PROJECT_FOLDER_NAME: MAAS-TXIHelper
       PROJECT_NAME: MAAS_TXIHelper
       MAJOR_VERSION: 1
       MINOR_VERSION: 0
-      PATCH_VERSION: 0
+      PATCH_VERSION: 1
       BUILD_NUMBER: ${{ github.run_number }}
 
     steps:
@@ -72,10 +69,9 @@ jobs:
     - name: Update hint paths in the csproj file
       run: |
         .\.github\workflows\Update-EsapiHintPaths.ps1 `
-        -CsprojFilePath .\MAAS-TXIHelper `
-        -CsprojFileName MAAS_TXIHelper.csproj
-        
- #Implemeting modern "PackageReferene" support for NuGet in VS2019 / VS2022          
+        -CsprojFilePath .\${{ env.PROJECT_FOLDER_NAME }} `
+        -CsprojFileName ${{ env.PROJECT_NAME }}.csproj
+
     - name: Build Solution
       run: msbuild.exe .\${{env.PROJECT_FOLDER_NAME}}\${{env.PROJECT_NAME}}.sln /nologo /nr:false /p:DeleteExistingFiles=True /p:platform="x64" /p:configuration="Release" /restore
         

--- a/MAAS-TXIHelper/MAAS_TXIHelper.csproj
+++ b/MAAS-TXIHelper/MAAS_TXIHelper.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MAAS_TXIHelper</RootNamespace>
     <AssemblyName>MAAS_TXIHelper.esapi</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkProfile />
@@ -98,11 +98,12 @@
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
     <Reference Include="VMS.TPS.Common.Model.API">
-      <HintPath>..\..\MAAS-BreastPlan-helper\VMS.TPS.Common.Model.API.dll</HintPath>
+      <HintPath Condition="Exists('C:\Program Files (x86)\Varian\RTM\16.1\esapi\API')">C:\Program Files (x86)\Varian\RTM\16.1\esapi\API\VMS.TPS.Common.Model.API.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VMS.TPS.Common.Model.Types">
-      <HintPath>..\..\MAAS-BreastPlan-helper\VMS.TPS.Common.Model.Types.dll</HintPath>
+      <HintPath Condition="Exists('C:\Program Files (x86)\Varian\RTM\16.1\esapi\API')">C:\Program Files (x86)\Varian\RTM\16.1\esapi\API\VMS.TPS.Common.Model.Types.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
@@ -201,17 +202,18 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm">
-      <Version>8.2.2</Version>
+      <Version>8.0.0</Version>
     </PackageReference>
     <PackageReference Include="fo-dicom">
       <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
-      <Version>8.0.0</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="SimpleITK-win64-CSharp-x64">
       <Version>1.0.0.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="packages\Microsoft.NETFramework.ReferenceAssemblies.net461.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net461.targets" Condition="'$(TargetFramework)' == 'net461' or Exists('packages\Microsoft.NETFramework.ReferenceAssemblies.net461.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net461.targets')" />
 </Project>

--- a/MAAS-TXIHelper/MAAS_TXIHelper.sln
+++ b/MAAS-TXIHelper/MAAS_TXIHelper.sln
@@ -24,12 +24,8 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2FC15AB5-D196-45CB-AD50-CF6B7C7AB038}.Debug|x64.ActiveCfg = Debug|x64
 		{2FC15AB5-D196-45CB-AD50-CF6B7C7AB038}.Debug|x64.Build.0 = Debug|x64
-		{2FC15AB5-D196-45CB-AD50-CF6B7C7AB038}.Debug|x86.ActiveCfg = Debug|x86
-		{2FC15AB5-D196-45CB-AD50-CF6B7C7AB038}.Debug|x86.Build.0 = Debug|x86
 		{2FC15AB5-D196-45CB-AD50-CF6B7C7AB038}.Release|x64.ActiveCfg = Release|x64
 		{2FC15AB5-D196-45CB-AD50-CF6B7C7AB038}.Release|x64.Build.0 = Release|x64
-		{2FC15AB5-D196-45CB-AD50-CF6B7C7AB038}.Release|x86.ActiveCfg = Release|x64
-		{2FC15AB5-D196-45CB-AD50-CF6B7C7AB038}.Release|x86.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MAAS-TXIHelper/ViewModels/FinalizeViewModel.cs
+++ b/MAAS-TXIHelper/ViewModels/FinalizeViewModel.cs
@@ -75,15 +75,15 @@ namespace MAAS_TXIHelper.ViewModels
                     TextBox += $"No plan selected. Please select a plan or plan sum to proceed.\n";
                     return;
                 }
-                IEnumerable<PlanSetup> planSetups = new List<PlanSetup>();
+                IList<PlanSetup> planSetups = new List<PlanSetup>();
                 if (scriptContext.PlanSetup != null)
                 {
-                    planSetups.Append(scriptContext.PlanSetup);
+                    planSetups.Add(scriptContext.PlanSetup);
                 }
                 else if (scriptContext.PlanSum != null)
                 {
                     TextBox += $"This plan sum is currently open: {scriptContext.PlanSum.Id}. All the included plans will be processed.\n";
-                    planSetups = scriptContext.PlanSum.PlanSetups;
+                    planSetups = scriptContext.PlanSum.PlanSetups.ToList();
                 }
                 foreach(PlanSetup planSetup in planSetups)
                 {

--- a/MAAS-TXIHelper/app.config
+++ b/MAAS-TXIHelper/app.config
@@ -12,4 +12,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>


### PR DESCRIPTION
Update Github actions to use `windows-2022`. Couple small modification to support all Eclipse versions.